### PR TITLE
aiservice 测试运行问题解决

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pip install:*)",
+      "Bash(python3:*)",
+      "Bash(pip3 show:*)",
+      "Bash(pip3:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "Bash(pip install:*)",
       "Bash(python3:*)",
       "Bash(pip3 show:*)",
-      "Bash(pip3:*)"
+      "Bash(pip3:*)",
+      "Bash(cat:*)"
     ],
     "deny": [],
     "ask": []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@
 - 数据库: Redis
 - 消息队列: Celery + Redis
 - 文件存储: 本地文件系统 (/tmp/tfboys)
-- AI 服务: OpenAI GPT-4/Claude, DALL-E 3, 七牛云 TTS
+- AI 服务: 七牛 AI Token API (DeepSeek-V3, Gemini 2.5 Flash), 七牛云 TTS
 
 **架构**: Monorepo (所有服务在一个仓库中)
 
@@ -59,7 +59,7 @@ backend/<service-name>/
 ### 3. services/ vs utils/ 的区别
 
 **services/** (业务逻辑层):
-- 调用外部服务的客户端 (GPT-4, DALL-E 3, Video Service)
+- 调用外部服务的客户端 (DeepSeek-V3, 七牛文生图 API, Video Service)
 - 包含业务逻辑的服务类
 - 示例: `text_analyzer.py`, `image_generator.py`, `video_client.py`
 
@@ -91,7 +91,7 @@ backend/<service-name>/
 4. **Pull Request**: PR 标题和描述必须使用中文
 5. **文档**: 所有 Markdown 文档(.md)必须使用中文
 6. **专有名词例外**: 以下技术术语可保留英文:
-   - API 名称 (如 OpenAI API, Claude API, DALL-E 3)
+   - API 名称 (如 OpenAI API, 七牛 AI 推理 API, 七牛文生图 API)
    - 框架名称 (如 FastAPI, React, Redis)
    - 技术术语 (如 HTTP, REST, JSON, Docker)
    - 第三方服务名称 (如 GitHub, Celery)
@@ -110,7 +110,7 @@ async def generate_image(scene_desc: str) -> str:
     Returns:
         str: 生成的图像 URL
     """
-    # 调用 DALL-E 3 API 生成图像
+    # 调用 七牛文生图 API API 生成图像
     response = await openai_client.create_image(scene_desc)
     return response.url
 
@@ -125,7 +125,7 @@ async def generate_image(scene_desc: str) -> str:
     Returns:
         str: Generated image URL
     """
-    # Call DALL-E 3 API to generate image
+    # Call 七牛文生图 API API to generate image
     response = await openai_client.create_image(scene_desc)
     return response.url
 ```
@@ -283,13 +283,13 @@ REDIS_URL=redis://localhost:6379/0
 VIDEO_SERVICE_URL=http://localhost:8003
 
 # OpenAI
-OPENAI_API_KEY=sk-...
+QINIU_API_KEY=sk-...
 
 # Anthropic
-ANTHROPIC_API_KEY=...
+QINIU_API_KEY=...
 
-# DALL-E 3 (使用 OpenAI API)
-# DALL-E 3 图像生成通过 OPENAI_API_KEY 实现，无需额外配置
+# 七牛文生图 API (使用 OpenAI API)
+# 七牛文生图 API 图像生成通过 QINIU_API_KEY 实现，无需额外配置
 
 # 七牛云 TTS
 QINIU_ACCESS_KEY=...
@@ -337,10 +337,10 @@ AI_SERVICE_URL=http://localhost:8002
 2. API Gateway → AI Service (创建任务)
    ↓
 3. AI Service 异步处理:
-   ├─ 3.1 文本分析 (GPT-4) → 生成场景列表
+   ├─ 3.1 文本分析 (DeepSeek-V3) → 生成场景列表
    ├─ 3.2 提取角色 → 保存到 Redis 角色库
-   ├─ 3.3 生成角色设定图 (DALL-E 3)
-   ├─ 3.4 生成场景图像 (DALL-E 3 + --cref)
+   ├─ 3.3 生成角色设定图 (七牛文生图 API)
+   ├─ 3.4 生成场景图像 (七牛文生图 API + --cref)
    ├─ 3.5 生成配音 (七牛云 TTS)
    └─ 3.6 提交到 Video Service
    ↓
@@ -351,11 +351,11 @@ AI_SERVICE_URL=http://localhost:8002
 6. 用户查询任务状态 → API Gateway → Redis
 ```
 
-### 角色一致性实现 (DALL-E 3)
+### 角色一致性实现 (七牛文生图 API)
 
-**核心原理**: 使用 DALL-E 3 通过详细的角色描述提示词来保持角色一致性
+**核心原理**: 使用 七牛文生图 API 通过详细的角色描述提示词来保持角色一致性
 
-**注意**: DALL-E 3 不支持图像引用参数（如 DALL-E 3 的 --cref），因此我们通过在每个场景的提示词中包含详细的角色特征描述来维持一致性。
+**注意**: 七牛文生图 API 不支持图像引用参数（如 七牛文生图 API 的 --cref），因此我们通过在每个场景的提示词中包含详细的角色特征描述来维持一致性。
 
 **步骤**:
 
@@ -547,11 +547,11 @@ ffmpeg_command = [
 
 ### 3. 如何扩展角色一致性算法?
 
-当前使用 DALL-E 3 的详细提示词策略，如需更高级的一致性:
+当前使用 七牛文生图 API 的详细提示词策略，如需更高级的一致性:
 
 1. 考虑使用 Stable Diffusion + ControlNet (支持图像引用)
 2. 使用专业的角色一致性模型 (如 InsightFace)
-3. 考虑 DALL-E 3 API 代理服务 (支持 --cref 参数)
+3. 考虑 七牛文生图 API API 代理服务 (支持 --cref 参数)
 4. 在 `app/services/character_manager.py` 中实现新算法
 
 ### 4. 如何添加新的配音音色?
@@ -590,7 +590,7 @@ docker-compose logs -f ai-service
 
 - [FastAPI 文档](https://fastapi.tiangolo.com/)
 - [Celery 文档](https://docs.celeryproject.org/)
-- [OpenAI DALL-E 3 文档](https://platform.openai.com/docs/guides/images)
+- [OpenAI 七牛文生图 API 文档](https://platform.openai.com/docs/guides/images)
 - [阿里云 OSS 文档](https://help.aliyun.com/product/31815.html)
 - [七牛云 TTS 文档](https://developer.qiniu.com/dora/8091/speech-synthesis)
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Token Free Boys - 基于大模型的小说文字转动漫视频系统
 
 ### 核心特性
 
-- 🎨 **角色一致性**: 使用Midjourney的--cref参数保证角色在不同场景的视觉一致性
-- 🤖 **AI驱动**: 基于GPT-4/Claude进行文本分析,Midjourney生成图像,阿里云TTS生成配音
+- 🎨 **角色一致性**: 通过详细的提示词描述保证角色在不同场景的视觉一致性
+- 🤖 **AI驱动**: 基于七牛 AI Token API，使用 DeepSeek-V3 进行文本分析，Gemini 2.5 Flash 生成图像，七牛 TTS 生成配音
 - 🎬 **自动化视频合成**: 使用FFmpeg自动合成图片、字幕和音频
 - 📦 **Monorepo架构**: 前后端代码在同一仓库,便于管理和部署
 - 🐳 **Docker支持**: 完整的Docker配置,一键启动所有服务
@@ -25,9 +25,10 @@ Token Free Boys - 基于大模型的小说文字转动漫视频系统
 ### 后端
 - Python + FastAPI
 - Celery + Redis (异步任务队列)
-- OpenAI GPT-4 / Claude 3.5 (文本分析)
-- Midjourney API (图像生成)
-- 阿里云TTS (配音生成)
+- 七牛 AI Token API
+  - DeepSeek-V3 (文本分析)
+  - Gemini 2.5 Flash (图像生成)
+  - 七牛 TTS (配音生成)
 - FFmpeg (视频合成)
 
 ## 快速开始
@@ -128,18 +129,21 @@ make clean     # 清理临时文件
 
 ### AI Service (.env)
 ```env
-OPENAI_API_KEY=sk-xxx
-MIDJOURNEY_API_KEY=xxx
-ALIYUN_TTS_ACCESS_KEY=xxx
-ALIYUN_TTS_SECRET_KEY=xxx
-OSS_ENDPOINT=xxx
-OSS_BUCKET=xxx
+# 七牛 AI Token API 配置
+QINIU_API_KEY=your-qiniu-ai-token-api-key
+
+# 七牛 TTS 服务配置
+QINIU_ACCESS_KEY=your-qiniu-access-key
+QINIU_SECRET_KEY=your-qiniu-secret-key
+
+# Redis 配置
+REDIS_URL=redis://localhost:6379/0
 ```
 
 ### Video Service (.env)
 ```env
-OSS_ENDPOINT=xxx
-OSS_BUCKET=xxx
+# Redis 配置
+REDIS_URL=redis://localhost:6379/0
 ```
 
 ## License

--- a/backend/ai-service/.env.example
+++ b/backend/ai-service/.env.example
@@ -1,8 +1,11 @@
+# 基础服务配置
 REDIS_URL=redis://localhost:6379/0
 VIDEO_SERVICE_URL=http://localhost:8002
 
-OPENAI_API_KEY=sk-xxx
-ANTHROPIC_API_KEY=sk-ant-xxx
+# 七牛 AI Token API 配置
+# 获取方式: https://portal.qiniu.com/kodo/ak-sk
+QINIU_API_KEY=your-qiniu-ai-token-api-key
 
-QINIU_ACCESS_KEY=xxx
-QINIU_SECRET_KEY=xxx
+# 七牛 TTS 服务配置 (用于语音生成)
+QINIU_ACCESS_KEY=your-qiniu-access-key
+QINIU_SECRET_KEY=your-qiniu-secret-key

--- a/backend/ai-service/README.md
+++ b/backend/ai-service/README.md
@@ -4,21 +4,82 @@
 
 ## 主要功能
 
-- 📝 **文本分析**: 使用GPT-4/Claude分析小说文本
-- 🎨 **图像生成**: 调用Midjourney API生成动漫风格图像  
-- 👤 **角色一致性**: 使用--cref参数保持角色视觉一致性
-- 🎙️ **配音生成**: 调用阿里云TTS生成中文配音
+- 📝 **文本分析**: 使用七牛 AI 推理 API (DeepSeek-V3) 分析小说文本，智能分割场景
+- 🎨 **图像生成**: 使用七牛文生图 API (Gemini 2.5 Flash) 生成动漫风格图像
+- 👤 **角色一致性**: 通过详细的提示词描述保持角色视觉一致性
+- 🎙️ **配音生成**: 调用七牛 TTS 生成高质量中文配音
+
+## 技术栈
+
+- **AI 服务**: 七牛 AI Token API
+  - 文本分析模型: `deepseek-v3`
+  - 图像生成模型: `gemini-2.5-flash-image`
+- **异步任务**: Celery + Redis
+- **Web 框架**: FastAPI
+- **存储**: 本地文件存储
 
 ## 开发
 
+### 安装依赖
+
 ```bash
+# 安装 shared 模块（在项目根目录执行）
+pip install -e ./shared
+
+# 安装服务依赖
+cd backend/ai-service
 pip install -r requirements.txt
+pip install -r requirements-test.txt
+```
+
+### 配置环境变量
+
+```bash
+cp .env.example .env
+# 编辑 .env 文件，填入七牛 API 密钥
+```
+
+### 启动服务
+
+```bash
+# 启动 API 服务
 uvicorn app.main:app --reload --port 8001
 
-# Celery Worker
+# 启动 Celery Worker
 celery -A app.workers.celery_app worker --loglevel=info
+```
+
+### 运行测试
+
+```bash
+# 运行所有单元测试
+python run_tests.py --unit
+
+# 运行测试并生成覆盖率报告
+python run_tests.py --unit --cov
 ```
 
 ## 环境变量
 
-参见 `.env.example` 文件
+参见 `.env.example` 文件：
+
+```bash
+# 七牛 AI Token API 配置
+QINIU_API_KEY=your-qiniu-ai-token-api-key
+
+# 七牛 TTS 服务配置
+QINIU_ACCESS_KEY=your-qiniu-access-key
+QINIU_SECRET_KEY=your-qiniu-secret-key
+
+# Redis 配置
+REDIS_URL=redis://localhost:6379/0
+
+# Video Service URL
+VIDEO_SERVICE_URL=http://localhost:8002
+```
+
+## API 文档
+
+启动服务后访问:
+- Swagger UI: http://localhost:8001/docs
+- ReDoc: http://localhost:8001/redoc

--- a/backend/ai-service/app/config.py
+++ b/backend/ai-service/app/config.py
@@ -3,36 +3,29 @@ from pydantic import field_validator
 
 
 class Settings(BaseSettings):
+    # 基础服务配置
     redis_url: str = "redis://localhost:6379/0"
     video_service_url: str = "http://localhost:8003"
-    
-    openai_api_key: str = ""
-    anthropic_api_key: str = ""
-    
-    qiniu_access_key: str = ""
-    qiniu_secret_key: str = ""
-    
-    @field_validator("openai_api_key")
+
+    # 七牛 AI Token API 配置
+    qiniu_api_key: str = ""  # 七牛 AI Token API Key (用于图像生成和文本分析)
+    qiniu_access_key: str = ""  # 七牛 Access Key (用于 TTS)
+    qiniu_secret_key: str = ""  # 七牛 Secret Key (用于 TTS)
+
+    @field_validator("qiniu_api_key")
     @classmethod
-    def validate_openai_key(cls, v: str) -> str:
+    def validate_qiniu_api_key(cls, v: str) -> str:
         if not v or not v.strip():
-            raise ValueError("OPENAI_API_KEY is required for image generation")
+            raise ValueError("QINIU_API_KEY is required for AI services")
         return v
-    
-    @field_validator("anthropic_api_key")
-    @classmethod
-    def validate_anthropic_key(cls, v: str) -> str:
-        if not v or not v.strip():
-            raise ValueError("ANTHROPIC_API_KEY is required for text analysis")
-        return v
-    
+
     @field_validator("qiniu_access_key", "qiniu_secret_key")
     @classmethod
     def validate_qiniu_keys(cls, v: str) -> str:
         if not v or not v.strip():
             raise ValueError("Qiniu TTS credentials are required")
         return v
-    
+
     class Config:
         env_file = ".env"
 

--- a/backend/ai-service/app/services/image_generator.py
+++ b/backend/ai-service/app/services/image_generator.py
@@ -1,8 +1,9 @@
 """
-图像生成服务 - 使用 OpenAI DALL-E 3 API 生成动漫风格图像
+图像生成服务 - 使用七牛文生图 API 生成动漫风格图像
 """
 import httpx
 import logging
+import base64
 from typing import Optional
 from openai import AsyncOpenAI
 from app.config import settings
@@ -14,11 +15,18 @@ logger = logging.getLogger(__name__)
 
 
 class ImageGenerator:
+    """图像生成器 - 基于七牛 AI Token API"""
+
     def __init__(self):
-        self.client = AsyncOpenAI(api_key=settings.openai_api_key)
-        self.model = "dall-e-3"
+        # 七牛 AI Token API 使用 OpenAI SDK 兼容接口
+        self.client = AsyncOpenAI(
+            base_url="https://openai.qiniu.com/v1",
+            api_key=settings.qiniu_api_key
+        )
+        # 使用七牛支持的图像生成模型
+        self.model = "gemini-2.5-flash-image"
         self.quality = "standard"
-    
+
     async def generate_character_image(
         self,
         character_name: str,
@@ -26,13 +34,13 @@ class ImageGenerator:
     ) -> str:
         """
         生成角色设定图
-        
+
         Args:
             character_name: 角色名称
             character_description: 角色外貌描述
-        
+
         Returns:
-            str: 上传到 OSS 后的图像 URL
+            str: 上传到本地存储后的图像路径
         """
         prompt = (
             f"Anime style character design sheet for {character_name}. "
@@ -40,18 +48,18 @@ class ImageGenerator:
             f"Full body character design, white background, character sheet style, "
             f"high quality anime illustration, detailed character design."
         )
-        
+
         logger.info(f"Generating character image for '{character_name}'")
-        
+
         image_url = await self._generate_and_upload(
             prompt=prompt,
             size="1024x1024",
             object_key=f"characters/{character_name.replace(' ', '_')}.png"
         )
-        
+
         logger.info(f"Character image generated for '{character_name}': {image_url}")
         return image_url
-    
+
     async def generate_scene_image(
         self,
         scene_description: str,
@@ -60,36 +68,33 @@ class ImageGenerator:
     ) -> str:
         """
         生成场景图像
-        
-        注意: DALL-E 3 不支持 --cref 参数,但我们可以在 prompt 中描述角色特征
-        以保持一定的角色一致性
-        
+
         Args:
             scene_description: 场景描述
             scene_id: 场景ID (用于生成文件名)
             character_context: 角色上下文描述 (可选,用于保持角色一致性)
-        
+
         Returns:
-            str: 上传到 OSS 后的图像 URL
+            str: 上传到本地存储后的图像路径
         """
         prompt = f"Anime style scene. {scene_description}."
-        
+
         if character_context:
             prompt += f" Characters in scene: {character_context}."
-        
+
         prompt += " Cinematic composition, high quality anime illustration, detailed background."
-        
+
         logger.info(f"Generating scene image for scene_id: {scene_id}")
-        
+
         image_url = await self._generate_and_upload(
             prompt=prompt,
-            size="1792x1024",
+            size="1792x1024",  # 16:9 横屏比例
             object_key=f"scenes/{scene_id}.png"
         )
-        
+
         logger.info(f"Scene image generated for {scene_id}: {image_url}")
         return image_url
-    
+
     @retry_on_failure(max_retries=3, delay=5.0, backoff=2.0)
     async def generate_image(
         self,
@@ -98,36 +103,36 @@ class ImageGenerator:
         ar: str = "16:9"
     ) -> str:
         """
-        通用图像生成接口 (兼容旧的 API)
-        
+        通用图像生成接口
+
         Args:
             prompt: 图像描述
-            character_ref_url: 角色参考图 URL (注意: DALL-E 3 不支持引用图像)
+            character_ref_url: 角色参考图 URL (注意: 当前不支持引用图像)
             ar: 宽高比 (支持: "1:1", "16:9", "9:16")
-        
+
         Returns:
-            str: 上传到 OSS 后的图像 URL
+            str: 上传到本地存储后的图像路径
         """
         size = self._get_size_from_aspect_ratio(ar)
-        
+
         if character_ref_url:
             logger.warning(
-                "DALL-E 3 does not support character reference images. "
+                "Qiniu text-to-image API does not support character reference images. "
                 "Character consistency will be maintained through detailed prompts only."
             )
-        
+
         full_prompt = f"{prompt}. High quality anime illustration."
-        
+
         logger.info(f"Generating image with prompt: {full_prompt[:100]}...")
-        
+
         image_url = await self._generate_and_upload(
             prompt=full_prompt,
             size=size,
             object_key=f"generated/{hash(full_prompt) % 10000000}.png"
         )
-        
+
         return image_url
-    
+
     @retry_on_failure(max_retries=3, delay=2.0, backoff=2.0)
     async def _generate_and_upload(
         self,
@@ -136,68 +141,88 @@ class ImageGenerator:
         object_key: str
     ) -> str:
         """
-        生成图像并上传到 OSS
-        
+        生成图像并上传到本地存储
+
         Args:
             prompt: 生成提示词
-            size: 图像尺寸 ("1024x1024", "1792x1024", "1024x1792")
-            object_key: OSS 对象键
-        
+            size: 图像尺寸 (如: "1024x1024", "1792x1024", "1024x1792")
+            object_key: 存储对象键
+
         Returns:
-            str: OSS 中的图像 URL
-            
+            str: 本地存储中的图像路径
+
         Raises:
             ImageGenerationException: 图像生成失败
         """
         try:
+            # 调用七牛文生图 API
             response = await self.client.images.generate(
                 model=self.model,
                 prompt=prompt,
                 size=size,
-                quality=self.quality,
                 n=1,
             )
-            
-            dalle_image_url = response.data[0].url
-            logger.info(f"DALL-E 3 image generated: {dalle_image_url}")
-            
-            async with httpx.AsyncClient() as client:
-                image_response = await client.get(dalle_image_url)
-                image_response.raise_for_status()
-                image_bytes = image_response.content
-            
+
+            # 七牛 API 返回 base64 编码的图片数据
+            if hasattr(response.data[0], 'b64_json'):
+                # Base64 格式
+                image_base64 = response.data[0].b64_json
+                image_bytes = base64.b64decode(image_base64)
+                logger.info(f"Qiniu image generated (base64 format)")
+            elif hasattr(response.data[0], 'url'):
+                # URL 格式 (备用)
+                image_url = response.data[0].url
+                logger.info(f"Qiniu image generated: {image_url}")
+
+                # 下载图片
+                async with httpx.AsyncClient() as client:
+                    image_response = await client.get(image_url)
+                    image_response.raise_for_status()
+                    image_bytes = image_response.content
+            else:
+                raise ImageGenerationException("Invalid response format from Qiniu API")
+
+            # 上传到本地存储
             local_path = await local_storage_client.upload_file(image_bytes, object_key)
-            
+
             logger.info(f"Image saved to local storage: {local_path}")
             return local_path
-            
+
         except Exception as e:
             logger.error(f"Failed to generate and upload image: {str(e)}", exc_info=True)
             raise ImageGenerationException(f"Failed to generate and upload image: {str(e)}")
-    
+
     def _get_size_from_aspect_ratio(self, ar: str) -> str:
         """
-        根据宽高比获取 DALL-E 3 支持的尺寸
-        
+        根据宽高比获取七牛 API 支持的尺寸
+
+        支持的尺寸:
+        - 正方形: 1024x1024
+        - 横屏: 1536x1024, 1792x1024, 1344x768
+        - 竖屏: 1024x1536, 1024x1792, 768x1344
+
         Args:
-            ar: 宽高比 ("1:1", "16:9", "9:16")
-        
+            ar: 宽高比 ("1:1", "16:9", "9:16", "4:3", "3:4")
+
         Returns:
-            str: DALL-E 3 尺寸 ("1024x1024", "1792x1024", "1024x1792")
+            str: 图像尺寸
         """
         size_map = {
             "1:1": "1024x1024",
             "16:9": "1792x1024",
             "9:16": "1024x1792",
+            "4:3": "1344x768",
+            "3:4": "768x1344",
         }
         size = size_map.get(ar, "1024x1024")
         if ar not in size_map:
             logger.warning(f"Unsupported aspect ratio '{ar}', using default 1024x1024")
         return size
-    
+
     async def close(self):
-        """关闭OpenAI客户端"""
+        """关闭客户端"""
         await self.client.close()
 
 
+# 全局单例
 image_generator = ImageGenerator()

--- a/backend/ai-service/app/services/text_analyzer.py
+++ b/backend/ai-service/app/services/text_analyzer.py
@@ -1,11 +1,10 @@
 """
-文本分析服务 - 使用GPT-4/Claude分析小说文本
+文本分析服务 - 使用七牛 AI 推理 API 分析小说文本
 """
 from typing import List, Dict
 import json
 import logging
-import asyncio
-from anthropic import Anthropic
+from openai import AsyncOpenAI
 from app.config import settings
 from shared.exceptions import TextAnalysisException
 
@@ -13,18 +12,24 @@ logger = logging.getLogger(__name__)
 
 
 class TextAnalyzer:
-    """文本分析器,将小说文本分割为场景并识别角色"""
-    
+    """文本分析器 - 将小说文本分割为场景并识别角色"""
+
     def __init__(self):
-        self.client = Anthropic(api_key=settings.anthropic_api_key)
-    
+        # 使用七牛 AI Token API (OpenAI 兼容接口)
+        self.client = AsyncOpenAI(
+            base_url="https://openai.qiniu.com/v1",
+            api_key=settings.qiniu_api_key
+        )
+        # 使用 deepseek-v3 模型进行文本分析
+        self.model = "deepseek-v3"
+
     async def analyze_novel(self, novel_text: str) -> List[Dict]:
         """
         分析小说文本,分割场景并识别角色
-        
+
         Args:
             novel_text: 小说文本内容
-        
+
         Returns:
             List[Dict]: 场景列表,每个场景包含:
                 - scene_index: 场景索引 (int)
@@ -35,38 +40,69 @@ class TextAnalyzer:
                     - description: 角色外貌特征描述 (str)
         """
         logger.info(f"Analyzing novel text ({len(novel_text)} characters)...")
-        
+
         try:
             prompt = self._build_prompt(novel_text)
-            
-            response = await asyncio.to_thread(
-                self.client.messages.create,
-                model="claude-3-5-sonnet-20241022",
-                max_tokens=4096,
-                temperature=0.7,
+
+            # 调用七牛 AI 推理 API
+            response = await self.client.chat.completions.create(
+                model=self.model,
                 messages=[
                     {"role": "user", "content": prompt}
-                ]
+                ],
+                temperature=0.7,
+                max_tokens=4096,
+                stream=False,
             )
-            
-            result_text = response.content[0].text
+
+            result_text = response.choices[0].message.content
+
+            # 尝试提取 JSON（处理可能的markdown格式）
+            result_text = self._extract_json(result_text)
+
             result = json.loads(result_text)
-            
+
             scenes = result.get("scenes", [])
-            
+
+            # 归一化角色描述，确保同名角色描述一致
             scenes = self._normalize_character_descriptions(scenes)
-            
+
             logger.info(f"Successfully analyzed {len(scenes)} scenes")
-            
+
             return scenes
-            
+
         except json.JSONDecodeError as e:
             logger.error(f"Failed to parse JSON response: {str(e)}", exc_info=True)
-            raise TextAnalysisException(f"Invalid JSON response from Claude: {str(e)}")
+            raise TextAnalysisException(f"Invalid JSON response from Qiniu AI: {str(e)}")
         except Exception as e:
             logger.error(f"Failed to analyze novel: {str(e)}", exc_info=True)
             raise TextAnalysisException(str(e))
-    
+
+    def _extract_json(self, text: str) -> str:
+        """
+        从响应中提取 JSON 内容
+        处理可能被包裹在 markdown 代码块中的 JSON
+
+        Args:
+            text: 响应文本
+
+        Returns:
+            str: 提取的 JSON 字符串
+        """
+        text = text.strip()
+
+        # 如果被 markdown 代码块包裹，提取内容
+        if text.startswith("```json"):
+            text = text[7:]  # 去掉 ```json
+            if text.endswith("```"):
+                text = text[:-3]  # 去掉 ```
+        elif text.startswith("```"):
+            text = text[3:]
+            if text.endswith("```"):
+                text = text[:-3]
+
+        return text.strip()
+
     def _build_prompt(self, novel_text: str) -> str:
         """构建分析提示词"""
         text_length = len(novel_text)
@@ -76,7 +112,7 @@ class TextAnalyzer:
             suggested_scenes = "5-10个场景"
         else:
             suggested_scenes = "10-20个场景"
-        
+
         return f"""
 你是一个专业的小说场景分析专家,擅长将小说文本分割为适合视频制作的场景。
 
@@ -117,32 +153,35 @@ class TextAnalyzer:
 - 建议生成{suggested_scenes}
 - 只返回JSON,不要包含其他文字说明
 """
-    
+
     def _normalize_character_descriptions(self, scenes: List[Dict]) -> List[Dict]:
         """
         归一化角色描述,确保同名角色描述一致
-        
+
         Args:
             scenes: 场景列表
-            
+
         Returns:
             List[Dict]: 归一化后的场景列表
         """
+        # 收集所有角色的第一次出现描述
         characters_dict = {}
-        
+
         for scene in scenes:
             for char in scene.get("characters", []):
                 char_name = char.get("name")
                 if char_name and char_name not in characters_dict:
                     characters_dict[char_name] = char.get("description", "")
-        
+
+        # 使用收集到的描述统一所有场景中的角色描述
         for scene in scenes:
             for char in scene.get("characters", []):
                 char_name = char.get("name")
                 if char_name and char_name in characters_dict:
                     char["description"] = characters_dict[char_name]
-        
+
         return scenes
 
 
+# 全局单例
 text_analyzer = TextAnalyzer()

--- a/backend/ai-service/pytest.ini
+++ b/backend/ai-service/pytest.ini
@@ -1,10 +1,11 @@
 [pytest]
+pythonpath = /Users/jiangzhi/repo/tfboys
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 asyncio_mode = auto
-addopts = 
+addopts =
     -v
     --strict-markers
     --disable-warnings

--- a/backend/ai-service/requirements.txt
+++ b/backend/ai-service/requirements.txt
@@ -5,7 +5,6 @@ redis==5.0.1
 pydantic==2.5.0
 pydantic-settings==2.1.0
 openai==1.3.7
-anthropic==0.7.7
 httpx==0.25.2
 python-multipart==0.0.6
 tenacity==8.2.3

--- a/backend/ai-service/run_tests.py
+++ b/backend/ai-service/run_tests.py
@@ -9,6 +9,7 @@ AI Service 测试统一入口
     python run_tests.py --cov              # 运行测试并生成覆盖率报告
 """
 import sys
+import os
 import subprocess
 import argparse
 
@@ -45,8 +46,10 @@ def run_tests(test_type=None, coverage=False, verbose=False):
         cmd.append("-vv")
     
     print(f"\n▶️  Command: {' '.join(cmd)}\n")
-    
-    result = subprocess.run(cmd, cwd="/workspace/backend/ai-service")
+
+    # 使用脚本所在目录作为工作目录
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    result = subprocess.run(cmd, cwd=script_dir)
     
     if result.returncode == 0:
         print("\n✅ All tests passed!")

--- a/backend/ai-service/tests/conftest.py
+++ b/backend/ai-service/tests/conftest.py
@@ -36,21 +36,28 @@ def mock_local_storage_client():
 
 
 @pytest.fixture
-def mock_anthropic_client():
-    """Mock Anthropic客户端"""
-    mock_client = MagicMock()
-    mock_response = MagicMock()
-    mock_response.content = [MagicMock(text='{"scenes": []}')]
-    mock_client.messages.create = MagicMock(return_value=mock_response)
+def mock_qiniu_text_client():
+    """Mock 七牛 AI 文本推理客户端"""
+    mock_client = AsyncMock()
+    mock_response = AsyncMock()
+    mock_choice = AsyncMock()
+    mock_message = AsyncMock()
+    mock_message.content = '{"scenes": []}'
+    mock_choice.message = mock_message
+    mock_response.choices = [mock_choice]
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
     return mock_client
 
 
 @pytest.fixture
-def mock_openai_client():
-    """Mock OpenAI客户端"""
+def mock_qiniu_image_client():
+    """Mock 七牛文生图客户端"""
     mock_client = AsyncMock()
     mock_response = AsyncMock()
-    mock_response.data = [AsyncMock(url="https://example.com/image.png")]
+    # 七牛 API 返回 base64 或 URL 格式
+    mock_data = AsyncMock()
+    mock_data.url = "https://example.com/image.png"
+    mock_response.data = [mock_data]
     mock_client.images.generate = AsyncMock(return_value=mock_response)
     mock_client.close = AsyncMock()
     return mock_client

--- a/shared/clients/__init__.py
+++ b/shared/clients/__init__.py
@@ -1,7 +1,14 @@
 """
 共享客户端模块
 """
-from .redis_client import RedisClient, redis_client
-from .local_storage_client import LocalStorageClient, local_storage_client
+from .redis_client import RedisClient, redis_client, init_redis_client
+from .local_storage_client import LocalStorageClient, local_storage_client, init_local_storage_client
 
-__all__ = ["RedisClient", "redis_client", "LocalStorageClient", "local_storage_client"]
+__all__ = [
+    "RedisClient",
+    "redis_client",
+    "init_redis_client",
+    "LocalStorageClient",
+    "local_storage_client",
+    "init_local_storage_client",
+]

--- a/shared/setup.py
+++ b/shared/setup.py
@@ -1,0 +1,26 @@
+"""
+TFBoys Shared Module Setup
+
+共享模块安装配置文件
+"""
+from setuptools import setup, find_packages
+
+setup(
+    name="tfboys-shared",
+    version="1.0.0",
+    description="TFBoys项目共享模块 - 包含通用模型、客户端和工具",
+    author="TFBoys Team",
+    packages=find_packages(),
+    python_requires=">=3.9",
+    install_requires=[
+        "redis>=5.0.1",
+        "pydantic>=2.5.0",
+    ],
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+)


### PR DESCRIPTION
我已成功将 AI Service 从 DALL-E/Midjourney 和 Claude 迁移到七牛 AI Token API。以下是完成的所有工作：
📋 已完成的迁移任务
1. 代码迁移 ✅
图像生成服务 ([image_generator.py](vscode-webview://11gafapbdbkkk06tlerdrlfv6apuebeqeuskte5f78vctk6nsg0e/backend/ai-service/app/services/image_generator.py))
✅ 从 OpenAI DALL-E 3 切换到七牛文生图 API
✅ 使用 gemini-2.5-flash-image 模型
✅ 支持 base64 和 URL 两种响应格式
✅ 支持多种图片尺寸: 1024x1024, 1792x1024, 1024x1792, 1344x768, 768x1344
✅ 保持原有的 API 接口不变
文本分析服务 ([text_analyzer.py](vscode-webview://11gafapbdbkkk06tlerdrlfv6apuebeqeuskte5f78vctk6nsg0e/backend/ai-service/app/services/text_analyzer.py))
✅ 从 Anthropic Claude 切换到七牛 AI 推理 API
✅ 使用 deepseek-v3 模型进行文本分析
✅ 添加 JSON 提取功能，处理 markdown 代码块包装
✅ 保持原有的场景分析逻辑不变
2. 配置更新 ✅
Config ([config.py](vscode-webview://11gafapbdbkkk06tlerdrlfv6apuebeqeuskte5f78vctk6nsg0e/backend/ai-service/app/config.py))
✅ 移除 OPENAI_API_KEY 和 ANTHROPIC_API_KEY
✅ 添加 QINIU_API_KEY (统一用于图像生成和文本分析)
✅ 保留 QINIU_ACCESS_KEY 和 QINIU_SECRET_KEY (用于 TTS)
✅ 更新配置验证逻辑
环境变量
✅ 更新 [.env.example](vscode-webview://11gafapbdbkkk06tlerdrlfv6apuebeqeuskte5f78vctk6nsg0e/backend/ai-service/.env.example)
✅ 更新 [.env](vscode-webview://11gafapbdbkkk06tlerdrlfv6apuebeqeuskte5f78vctk6nsg0e/backend/ai-service/.env) (测试用)
✅ 简化配置，只需一个 API Key
依赖管理 ([requirements.txt](vscode-webview://11gafapbdbkkk06tlerdrlfv6apuebeqeuskte5f78vctk6nsg0e/backend/ai-service/requirements.txt))
✅ 移除 anthropic==0.7.7
✅ 保留 openai==1.3.7 (用于兼容七牛 API)
✅ 保持其他依赖不变
3. 文档更新 ✅
AI Service README ([backend/ai-service/README.md](vscode-webview://11gafapbdbkkk06tlerdrlfv6apuebeqeuskte5f78vctk6nsg0e/backend/ai-service/README.md))
✅ 更新技术栈说明
✅ 更新环境变量配置说明
✅ 添加七牛 AI Token API 相关信息
主 README ([README.md](vscode-webview://11gafapbdbkkk06tlerdrlfv6apuebeqeuskte5f78vctk6nsg0e/README.md))
✅ 更新核心特性描述
✅ 更新技术栈列表
✅ 更新环境变量配置示例
CLAUDE.md ([CLAUDE.md](vscode-webview://11gafapbdbkkk06tlerdrlfv6apuebeqeuskte5f78vctk6nsg0e/CLAUDE.md))
✅ 批量替换 API 名称
DALL-E 3 → 七牛文生图 API
GPT-4 → DeepSeek-V3
Claude API → 七牛 AI 推理 API
OPENAI_API_KEY → QINIU_API_KEY
4. 测试更新 ✅
测试配置 ([tests/conftest.py](vscode-webview://11gafapbdbkkk06tlerdrlfv6apuebeqeuskte5f78vctk6nsg0e/backend/ai-service/tests/conftest.py))
✅ 添加 mock_qiniu_text_client fixture
✅ 添加 mock_qiniu_image_client fixture
✅ 移除旧的 mock_anthropic_client 和 mock_openai_client