### PR TITLE
refactor: 将切片信息数组作为 props 传递给 VideoSliceCarousel 组件

### DIFF
--- a/frontend/src/components/VideoSliceCarousel.tsx
+++ b/frontend/src/components/VideoSliceCarousel.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react"
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel"
+import { VideoSlice } from "@/data/mockData"
+
+interface VideoSliceCarouselProps {
+  slices: VideoSlice[]
+  onSliceClick: (index: number, timeInSeconds: number) => void
+  currentSliceIndex?: number
+}
+
+export function VideoSliceCarousel({
+  slices,
+  onSliceClick,
+  currentSliceIndex = 0,
+}: VideoSliceCarouselProps) {
+  return (
+    <Carousel
+      opts={{
+        align: "start",
+      }}
+      className="w-full"
+    >
+      <CarouselContent>
+        {slices.map((slice, index) => (
+          <CarouselItem key={slice.id} className="basis-1/3 lg:basis-1/4">
+            <button
+              onClick={() => onSliceClick(index, slice.timeInSeconds)}
+              className={`
+                w-full rounded-lg overflow-hidden border-2 transition-all
+                ${
+                  currentSliceIndex === index
+                    ? "border-primary ring-2 ring-primary/20"
+                    : "border-border hover:border-primary/50"
+                }
+              `}
+            >
+              <div className="aspect-video bg-muted">
+                <img
+                  src={slice.thumbnailUrl}
+                  alt={`场景 ${slice.sceneNumber}`}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              <div className="p-2 bg-background">
+                <p className="text-xs font-medium">场景 {slice.sceneNumber}</p>
+                <p className="text-xs text-muted-foreground">{slice.timestamp}</p>
+              </div>
+            </button>
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  )
+}

--- a/frontend/src/pages/MyTasksPage.tsx
+++ b/frontend/src/pages/MyTasksPage.tsx
@@ -12,13 +12,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import {
-  Carousel,
-  CarouselContent,
-  CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
-} from "@/components/ui/carousel"
-import {
   Search,
   Play,
   Download,
@@ -32,6 +25,7 @@ import {
   Maximize,
 } from "lucide-react"
 import { mockTasks, mockVideoSlices, getTaskStatusText, getTaskStatusVariant, Task } from "@/data/mockData"
+import { VideoSliceCarousel } from "@/components/VideoSliceCarousel"
 
 type FilterStatus = "all" | "in-progress" | "completed" | "failed"
 
@@ -312,44 +306,11 @@ export function MyTasksPage() {
 
                 <div>
                   <h3 className="text-sm font-semibold mb-3">🎞️ 视频切片</h3>
-                  <Carousel
-                    opts={{
-                      align: "start",
-                    }}
-                    className="w-full"
-                  >
-                    <CarouselContent>
-                      {mockVideoSlices.map((slice, index) => (
-                        <CarouselItem key={slice.id} className="basis-1/3 lg:basis-1/4">
-                          <button
-                            onClick={() => handleSliceClick(index, slice.timeInSeconds)}
-                            className={`
-                              w-full rounded-lg overflow-hidden border-2 transition-all
-                              ${
-                                currentSliceIndex === index
-                                  ? "border-primary ring-2 ring-primary/20"
-                                  : "border-border hover:border-primary/50"
-                              }
-                            `}
-                          >
-                            <div className="aspect-video bg-muted">
-                              <img
-                                src={slice.thumbnailUrl}
-                                alt={`场景 ${slice.sceneNumber}`}
-                                className="w-full h-full object-cover"
-                              />
-                            </div>
-                            <div className="p-2 bg-background">
-                              <p className="text-xs font-medium">场景 {slice.sceneNumber}</p>
-                              <p className="text-xs text-muted-foreground">{slice.timestamp}</p>
-                            </div>
-                          </button>
-                        </CarouselItem>
-                      ))}
-                    </CarouselContent>
-                    <CarouselPrevious />
-                    <CarouselNext />
-                  </Carousel>
+                  <VideoSliceCarousel
+                    slices={mockVideoSlices}
+                    onSliceClick={handleSliceClick}
+                    currentSliceIndex={currentSliceIndex}
+                  />
                 </div>
               </div>
 

--- a/frontend/src/pages/VideoGenerationPage.tsx
+++ b/frontend/src/pages/VideoGenerationPage.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Upload, Link as LinkIcon, Play, Download, Share2, RefreshCw, Check } from "lucide-react"
 import { mockTemplateVideos, mockVideoSlices, mockGeneratedVideo } from "@/data/mockData"
+import { VideoSliceCarousel } from "@/components/VideoSliceCarousel"
 
 type VideoStyle = "古风" | "现代" | "动漫" | "奇幻" | "3D卡通"
 type VoiceType = "女声" | "男声" | "童声"
@@ -386,44 +387,11 @@ export function VideoGenerationPage() {
             {status === "completed" && (
               <Card className="p-6">
                 <h3 className="text-sm font-semibold mb-4">🎞️ 视频切片</h3>
-                <Carousel
-                  opts={{
-                    align: "start",
-                  }}
-                  className="w-full"
-                >
-                  <CarouselContent>
-                    {mockVideoSlices.map((slice, index) => (
-                      <CarouselItem key={slice.id} className="basis-1/3 lg:basis-1/4">
-                        <button
-                          onClick={() => handleSliceClick(index, slice.timeInSeconds)}
-                          className={`
-                            w-full rounded-lg overflow-hidden border-2 transition-all
-                            ${
-                              currentSliceIndex === index
-                                ? "border-primary ring-2 ring-primary/20"
-                                : "border-border hover:border-primary/50"
-                            }
-                          `}
-                        >
-                          <div className="aspect-video bg-muted">
-                            <img
-                              src={slice.thumbnailUrl}
-                              alt={`场景 ${slice.sceneNumber}`}
-                              className="w-full h-full object-cover"
-                            />
-                          </div>
-                          <div className="p-2 bg-background">
-                            <p className="text-xs font-medium">场景 {slice.sceneNumber}</p>
-                            <p className="text-xs text-muted-foreground">{slice.timestamp}</p>
-                          </div>
-                        </button>
-                      </CarouselItem>
-                    ))}
-                  </CarouselContent>
-                  <CarouselPrevious />
-                  <CarouselNext />
-                </Carousel>
+                <VideoSliceCarousel
+                  slices={mockVideoSlices}
+                  onSliceClick={handleSliceClick}
+                  currentSliceIndex={currentSliceIndex}
+                />
               </Card>
             )}
 


### PR DESCRIPTION
- 创建 VideoSliceCarousel 组件,接受 slices 数组作为 prop
- 更新 MyTasksPage 使用新组件并传递 mockVideoSlices
- 更新 VideoGenerationPage 使用新组件并传递 mockVideoSlices
- 移除两个页面中重复的视频切片轮播代码

🤖 Generated with [codeagent](https://github.com/qbox/codeagent)